### PR TITLE
lazyNew() does not work

### DIFF
--- a/config/Common.php
+++ b/config/Common.php
@@ -40,7 +40,7 @@ class Common extends Config
         $dispatcher = $di->get('aura/cli-kernel:dispatcher');
         $dispatcher->setObject(
             'help',
-            $di->newInstance('Aura\Cli_Kernel\HelpCommand')
+            $di->lazyNew('Aura\Cli_Kernel\HelpCommand')
         );
 
         $help_service = $di->get('aura/cli-kernel:help_service');

--- a/tests/CliKernelTest.php
+++ b/tests/CliKernelTest.php
@@ -1,7 +1,6 @@
 <?php
 namespace Aura\Cli_Kernel;
 
-use Aura\Di\ContainerBuilder;
 use Aura\Cli\Status;
 use Aura\Project_Kernel\Factory;
 


### PR DESCRIPTION
```sh-session
$ composer test
...
1) Aura\Cli_Kernel\CliKernelTest::testHelpCommand
TypeError: Argument 1 passed to Aura\Cli_Kernel\HelpCommand::__construct() must be an instance of Aura\Cli\Stdio, string given

/home/runner/work/Aura.Cli_Kernel/Aura.Cli_Kernel/src/HelpCommand.php:62
/home/runner/work/Aura.Cli_Kernel/Aura.Cli_Kernel/vendor/aura/di/src/Resolver/Blueprint.php:99
/home/runner/work/Aura.Cli_Kernel/Aura.Cli_Kernel/vendor/aura/di/src/Resolver/Resolver.php:140
/home/runner/work/Aura.Cli_Kernel/Aura.Cli_Kernel/vendor/aura/di/src/Injection/Factory.php:97
/home/runner/work/Aura.Cli_Kernel/Aura.Cli_Kernel/vendor/aura/dispatcher/src/InvokeMethodTrait.php:94
/home/runner/work/Aura.Cli_Kernel/Aura.Cli_Kernel/vendor/aura/dispatcher/src/Dispatcher.php:122
/home/runner/work/Aura.Cli_Kernel/Aura.Cli_Kernel/vendor/aura/dispatcher/src/Dispatcher.php:95
/home/runner/work/Aura.Cli_Kernel/Aura.Cli_Kernel/src/CliKernel.php:196
/home/runner/work/Aura.Cli_Kernel/Aura.Cli_Kernel/src/CliKernel.php:144
/home/runner/work/Aura.Cli_Kernel/Aura.Cli_Kernel/tests/CliKernelTest.php:24
/home/runner/work/Aura.Cli_Kernel/Aura.Cli_Kernel/tests/CliKernelTest.php:92
```
